### PR TITLE
地址脱敏功能优化，提升地址信息隐私保护

### DIFF
--- a/src/lib/mask/address.js
+++ b/src/lib/mask/address.js
@@ -8,15 +8,13 @@
  * @summary mask_address('13968341859')
  * @example
  * improt { mask_address } from 'jxk'
- * mask_address('江苏省南京市鼓楼区中山路 18 号德基广场写字楼 16 层') // 江苏****鼓楼区中山路 18 号德基广场写字楼 16 层
+ * mask_address('四川省成都市高新区三墩街道某某小区31栋123号') // 四川省成都市高新区**街****区**栋***号
  */
 export default (address) => {
-  if (!address) return null
-  if (address.length <= 3) {
-    return '*' + address.substring(1, address.length)
-  } else if (address.length > 3 && address.length <= 6) {
-    return '**' + address.substring(2, address.length)
-  } else if (address.length > 6) {
-    return address.substring(0, 2) + '****' + address.substring(6, address.length)
-  }
+  if (!address) return ''
+  const regexp = /.+?(区|镇|乡|街|路|号|弄|座|幢|栋|单元|楼|层|室)/g
+  const addArr = address.match(regexp)
+  const province = addArr.shift()
+  const encrypt = addArr.map(item => '*'.repeat(item.length - 1) + item.slice(-1)).join('')
+  return province + encrypt
 };


### PR DESCRIPTION
重构mask_address函数，实现对地址信息中敏感部分的自动遮蔽。现在可以更好地处理各种长度的地址，通过正则表达式匹配地址关键词，并对其进行部分替换为星号，保持地址结构的同时，增强隐私安全性。